### PR TITLE
Playing with the idea of a TTL Backend 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,6 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --all-features --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-features --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timed-option"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,20 @@ description = """
 A simple library for options with TTLs.
 """
 exclude = [".github"]
+
+
+[features]
+default = []
+serde = ["dep:serde"]
+chrono = ["dep:chrono"]
+
+[dependencies]
+serde = { version = "1.0", optional = true, default-features = false, features = [
+    "derive",
+] }
+chrono = { version = "0.4", optional = true, default-features = false, features = [
+    "now",
+] }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ A simple library for options with TTLs
 
 ```rust
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use timed_option::{TimedOption, TimedValue};
 
-let ttl = Duration::from_millis(100);
-let access_token = TimedOption::some("token", ttl);
+let ttl = Duration::from_millis(10);
+let access_token = TimedOption::<_, Instant>::new("token", ttl);
 assert_eq!(true, access_token.is_some());
 thread::sleep(ttl);
 assert_eq!(false, access_token.is_some());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ where
 /// * `Valid(T)` - Contains a value of type `T` that is considered valid.
 /// * `Expired(T)` - Contains a value of type `T` that has expired and is no longer considered valid.
 /// * `None` - Indicates the absence of a value.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TimedValue<T> {
     Valid(T),
     Expired(T),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@ where
 /// * `Expired(T)` - Contains a value of type `T` that has expired and is no longer considered valid.
 /// * `None` - Indicates the absence of a value.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TimedValue<T> {
     Valid(T),
     Expired(T),
@@ -252,5 +253,30 @@ impl TtlBackend for std::time::Instant {
     #[inline]
     fn is_expired(&self) -> bool {
         *self <= std::time::Instant::now()
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TtlBackend for chrono::DateTime<chrono::Utc> {
+    type Duration = chrono::Duration;
+
+    fn now() -> Self {
+        chrono::Utc::now()
+    }
+
+    fn expired() -> Self {
+        chrono::Utc::now()
+    }
+
+    fn add(self, dt: Self::Duration) -> Self {
+        self + dt
+    }
+
+    fn is_valid(&self) -> bool {
+        *self > chrono::Utc::now()
+    }
+
+    fn is_expired(&self) -> bool {
+        *self <= chrono::Utc::now()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ where
     /// Returns an `Option<T>`. If the value is some but expired a `None` is returned.
     #[inline]
     pub fn into_option(self) -> Option<T> {
-        match self.is_some() {
+        match self.ttl.is_valid() {
             true => self.value,
             false => None,
         }

--- a/tests/std_instant.rs
+++ b/tests/std_instant.rs
@@ -1,0 +1,26 @@
+use std::time::{Duration, Instant};
+
+use timed_option::{TimedOption, TimedValue};
+
+#[test]
+fn std_instant_backend() {
+    let ttl = Duration::from_secs(3500);
+    let mut token = TimedOption::<_, Instant>::new("space_patato", ttl);
+
+    assert!(token.is_some());
+    assert!(!token.is_none());
+
+    assert_eq!(token.into_option(), Some("space_patato"));
+    assert_eq!(token.into_timed_value(), TimedValue::Valid("space_patato"));
+
+    token.expire();
+
+    assert_eq!(token.into_option(), None);
+    assert_eq!(
+        token.into_timed_value(),
+        TimedValue::Expired("space_patato")
+    );
+
+    assert!(!token.is_some());
+    assert!(token.is_none());
+}

--- a/tests/timed_value.rs
+++ b/tests/timed_value.rs
@@ -1,0 +1,60 @@
+use timed_option::TimedValue;
+
+const TIMED_VALUE_NONE: TimedValue<()> = TimedValue::None;
+
+#[test]
+fn timed_value() {
+    assert!(TimedValue::Valid("But just remember how we shook, shook").is_valid());
+    assert!(!TimedValue::Expired("And all the things we took, took").is_valid());
+    assert!(!TIMED_VALUE_NONE.is_valid());
+
+    assert!(!TimedValue::Valid("This town's the oldest friend of mine").is_expired());
+    assert!(TimedValue::Expired("duu du-du du-du du-du --").is_expired());
+    assert!(!TIMED_VALUE_NONE.is_expired());
+
+    assert!(TimedValue::Valid("The sky is turning purple").has_value());
+    assert!(TimedValue::Expired("Then orange, then pink and yellow").has_value());
+    assert!(!TIMED_VALUE_NONE.has_value());
+
+    assert!(!TimedValue::Valid("But instead I stand still").is_none());
+    assert!(!TimedValue::Expired("heart cracking").is_none());
+    assert!(TIMED_VALUE_NONE.is_none());
+
+    assert_eq!(
+        TimedValue::Valid("I feel like summer").as_ref(),
+        TimedValue::Valid(&"I feel like summer")
+    );
+    assert_eq!(
+        TimedValue::Expired("We dream like we need to see").as_ref(),
+        TimedValue::Expired(&"We dream like we need to see")
+    );
+}
+
+#[test]
+fn timed_value_eq() {
+    assert_eq!(
+        TimedValue::Valid("thousand-year blood war"),
+        TimedValue::Valid("thousand-year blood war")
+    );
+
+    assert_eq!(
+        TimedValue::Expired("thousand-year blood war"),
+        TimedValue::Expired("thousand-year blood war")
+    );
+
+    assert_eq!(TIMED_VALUE_NONE, TimedValue::None);
+
+    assert_ne!(
+        TimedValue::Valid("thousand-year blood war"),
+        TimedValue::Expired("thousand-year blood war")
+    );
+    assert_ne!(
+        TimedValue::Valid("day eight thousand one hundred eighteen"),
+        TimedValue::None
+    );
+
+    assert_ne!(
+        TimedValue::Expired("But he replies with, 'Okay', every time, every time"),
+        TimedValue::None
+    );
+}


### PR DESCRIPTION
- adds `TtlBackend` trait for custom TTL logic
- some breaking api changes most notably removing `TimedOption::some` and `TimedOption::none` in favor of a single constructor `TimedOption::new`
- adds chrono backend via feature flag
- adds serde serialization to `TimeValue`